### PR TITLE
Use namespace from Rollouts resource to avoid unauthorized access to other HTTPProxies

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -138,7 +138,6 @@ func TestRunSuccessfully(t *testing.T) {
 func newRollout(stableSvc, canarySvc, httpProxyName string) *v1alpha1.Rollout {
 	contourConfig := ContourTrafficRouting{
 		HTTPProxy: httpProxyName,
-		Namespace: "default",
 	}
 	encodedContourConfig, err := json.Marshal(contourConfig)
 	if err != nil {


### PR DESCRIPTION
Closes #17 