### PR TITLE
feature: use patch strategy to update services weight

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // handshakeConfigs are used to just do a basic handshake between
-// a plugin and host. If the handshake fails, a user friendly error is shown.
+// a plugin and host. If the handshake fails, a user-friendly error is shown.
 // This prevents users from executing bad plugins or executing a plugin
 // directory. It is a UX feature, not a security feature.
 var handshakeConfig = goPlugin.HandshakeConfig{

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -1,0 +1,8 @@
+package plugin
+
+// Type holds this plugin type
+const Type = "Contour"
+
+// ConfigKey used to identify the plugin in argo-rollouts configmap.
+// see https://argoproj.github.io/argo-rollouts/features/traffic-management/plugins/
+const ConfigKey = "argoproj-labs/contour"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

use patch strategy to update services weight to avoid strongly dependent versions of contour.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
