### PR TITLE
fix: add missing permission

### DIFF
--- a/yaml/rbac.yaml
+++ b/yaml/rbac.yaml
@@ -8,6 +8,7 @@ rules:
       - list
       - watch
       - update
+      - patch
     apiGroups:
       - projectcontour.io
     resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Though patch permission is added in https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/pull/53, manifest is not updated yet. So I added `patch` permission to clusterrole.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
