### PR TITLE
Support canary services in multiple routes of the same proxy

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -280,6 +280,66 @@ func Test_createPatch(t *testing.T) {
 			wantPatchType: k8stypes.MergePatchType,
 			wantErr:       false,
 		},
+		{
+			name: "test create http proxy patch",
+			args: args{
+				httpProxy: &contourv1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mocks.HTTPProxyName,
+					},
+					Spec: contourv1.HTTPProxySpec{
+						Routes: []contourv1.Route{
+							{
+								Services: []contourv1.Service{
+									{
+										Name:   mocks.StableServiceName,
+										Weight: 70,
+									},
+									{
+										Name:   mocks.CanaryServiceName,
+										Weight: 20,
+									},
+									{
+										Name:   "others-service",
+										Weight: 10,
+									},
+								},
+							},
+							{
+								Services: []contourv1.Service{
+									{
+										Name:   mocks.StableServiceName,
+										Weight: 70,
+									},
+									{
+										Name:   mocks.CanaryServiceName,
+										Weight: 10,
+									},
+									{
+										Name:   "others-service",
+										Weight: 20,
+									},
+								},
+							},
+						},
+					},
+				},
+				rollout: &v1alpha1.Rollout{
+					Spec: v1alpha1.RolloutSpec{
+						Strategy: v1alpha1.RolloutStrategy{
+							Canary: &v1alpha1.CanaryStrategy{
+								StableService: mocks.StableServiceName,
+								CanaryService: mocks.CanaryServiceName,
+							},
+						},
+					},
+				},
+				desiredWeight: 50,
+			},
+			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":45},{"name":"argo-rollouts-canary","port":0,"weight":45},{"name":"others-service","port":0,"weight":10}]},{"services":[{"name":"argo-rollouts-stable","port":0,"weight":40},{"name":"argo-rollouts-canary","port":0,"weight":40},{"name":"others-service","port":0,"weight":20}]}]}}`),
+			wantPatchType: k8stypes.MergePatchType,
+			wantErr:       false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -292,7 +352,7 @@ func Test_createPatch(t *testing.T) {
 				t.Errorf("createPatch() gotPatchType = %v, want %v", gotPatchType, tt.wantPatchType)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("createPatch() got = %v, want %v", got, tt.want)
+				t.Errorf("createPatch() got = %s, want %s", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
closes #75 

**What this PR does / why we need it**:

Given an HTTPProxy template that looks like the following:
```
spec:
  routes:
  - conditions:
    - prefix: /foo
    services:
    - name: web
      weight: 100
    - name: web-canary
      weight: 0
  - conditions:
    - prefix: /bar
    services:
    - name: web
      weight: 100
    - name: web-canary
      weight: 0
```

Previously we would only update the weights of one of the routes, now we will update all the routes for the appropriate canary

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
