### PR TITLE
Ignore mirrored weights for weight check

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -264,7 +264,7 @@ func getRouteServices(httpProxy *contourv1.HTTPProxy, rollout *v1alpha1.Rollout)
 
 		otherWeight := int64(0)
 		for name, svc := range svcMap {
-			if name == stableSvcName || name == canarySvcName {
+			if name == stableSvcName || name == canarySvcName || svc.Mirror {
 				continue
 			}
 			otherWeight += svc.Weight


### PR DESCRIPTION
**What this PR does / why we need it**:
when checking "the total weight must equals to 100" we are including mirror weights, but with mirroring it's expected that weights will exceed 100%

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
