### PR TITLE
feat: upgrade argo-rollouts to v1.7.2 and go to 1.22.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour
 
 go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.22.6
 
 require (
-	github.com/argoproj/argo-rollouts v1.6.5
+	github.com/argoproj/argo-rollouts v1.7.2
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/hashicorp/go-plugin v1.6.1
 	github.com/projectcontour/contour v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/argoproj/argo-rollouts v1.6.5 h1:VDAp9PGboRbzd9tQJ/8IkaI+KrvWIRrpfSV5aeX0GUQ=
-github.com/argoproj/argo-rollouts v1.6.5/go.mod h1:X2kTiBaYCSounmw1kmONdIZTwJNzNQYC0SrXUgSw9UI=
+github.com/argoproj/argo-rollouts v1.7.2 h1:faDUH/qePerYRwsrHfVzNQkhjGBgXIiVYdVK8824kMo=
+github.com/argoproj/argo-rollouts v1.7.2/go.mod h1:Te4HrUELxKiBpK8lgk77o4gTa3mv8pXCd8xdPprKrbs=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrade argo-rollouts to v1.7.2 and go to 1.22.6

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
