### PR TITLE
Handle weights that do not sum to 100

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -309,6 +309,8 @@ func (r *RpcPlugin) verifyHTTPProxy(
 		return false, nil
 	}
 
+	normalizeManagedRouteWeights(httpProxy, rollout)
+
 	canarySvcs, stableSvcs, totalWeights, err := getRouteServices(httpProxy, rollout)
 	if err != nil {
 		return false, err

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -230,15 +230,38 @@ func normalizeWeights(route *contourv1.Route) {
 	boostWeights(route, 100)
 }
 
+func routeContainsService(route *contourv1.Route, serviceName string) bool {
+	for i := range route.Services {
+		if route.Services[i].Name == serviceName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeManagedRouteWeights(httpProxy *contourv1.HTTPProxy, rollout *v1alpha1.Rollout) {
+	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
+	if canaryServiceName == "" {
+		return
+	}
+
+	for i := range httpProxy.Spec.Routes {
+		if !routeContainsService(&httpProxy.Spec.Routes[i], canaryServiceName) {
+			continue
+		}
+
+		normalizeWeights(&httpProxy.Spec.Routes[i])
+	}
+}
+
 func createPatch(httpProxy *contourv1.HTTPProxy, rollout *v1alpha1.Rollout, canaryWeightPercent int32) ([]byte, types.PatchType, error) {
 	oldData, err := json.Marshal(httpProxy.DeepCopy())
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal the current configuration: %w", err)
 	}
 
-	for i := range httpProxy.Spec.Routes {
-		normalizeWeights(&httpProxy.Spec.Routes[i])
-	}
+	normalizeManagedRouteWeights(httpProxy, rollout)
 
 	canarySvcs, stableSvcs, totalWeights, err := getRouteServices(httpProxy, rollout)
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -171,10 +171,61 @@ func (r *RpcPlugin) updateHTTPProxy(
 	return nil
 }
 
+func usesDefaultWeights(route *contourv1.Route) bool {
+	for _, s := range route.Services {
+		if s.Weight != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func setDefaultWeights(route *contourv1.Route) {
+	if !usesDefaultWeights(route) {
+		return
+	}
+
+	for i := range route.Services {
+		route.Services[i].Weight = 1
+	}
+}
+
+func weightSum(route *contourv1.Route) int64 {
+	sum := int64(0)
+
+	for _, s := range route.Services {
+		sum += s.Weight
+	}
+
+	return sum
+}
+
+func boostWeights(route *contourv1.Route, factor int64) {
+	for i := range route.Services {
+		route.Services[i].Weight *= factor
+	}
+}
+
+func normalizeWeights(route *contourv1.Route) {
+	setDefaultWeights(route)
+
+	sum := weightSum(route)
+	if sum >= 100 {
+		return
+	}
+
+	boostWeights(route, 100)
+}
+
 func createPatch(httpProxy *contourv1.HTTPProxy, rollout *v1alpha1.Rollout, canaryWeightPercent int32) ([]byte, types.PatchType, error) {
 	oldData, err := json.Marshal(httpProxy.DeepCopy())
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal the current configuration: %w", err)
+	}
+
+	for i := range httpProxy.Spec.Routes {
+		normalizeWeights(&httpProxy.Spec.Routes[i])
 	}
 
 	canarySvcs, stableSvcs, totalWeights, err := getRouteServices(httpProxy, rollout)
@@ -262,22 +313,9 @@ func getRouteServices(httpProxy *contourv1.HTTPProxy, rollout *v1alpha1.Rollout)
 			return nil, nil, nil, err
 		}
 
-		otherWeight := int64(0)
-		for name, svc := range svcMap {
-			if name == stableSvcName || name == canarySvcName || svc.Mirror {
-				continue
-			}
-			otherWeight += svc.Weight
-		}
-
-		// the total weight must equals to 100
-		if otherWeight+canarySvc.Weight+stableSvc.Weight != 100 {
-			return nil, nil, nil, fmt.Errorf("the total weight must equals to 100")
-		}
-
 		canarySvcs = append(canarySvcs, canarySvc)
 		stableSvcs = append(stableSvcs, stableSvc)
-		totalWeights = append(totalWeights, 100-otherWeight)
+		totalWeights = append(totalWeights, canarySvc.Weight + stableSvc.Weight)
 	}
 
 	return canarySvcs, stableSvcs, totalWeights, nil

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -187,6 +187,10 @@ func setDefaultWeights(route *contourv1.Route) {
 	}
 
 	for i := range route.Services {
+		if route.Services[i].Mirror {
+			continue
+		}
+
 		route.Services[i].Weight = 1
 	}
 }
@@ -195,6 +199,10 @@ func weightSum(route *contourv1.Route) int64 {
 	sum := int64(0)
 
 	for _, s := range route.Services {
+		if s.Mirror {
+			continue
+		}
+
 		sum += s.Weight
 	}
 
@@ -203,6 +211,10 @@ func weightSum(route *contourv1.Route) int64 {
 
 func boostWeights(route *contourv1.Route, factor int64) {
 	for i := range route.Services {
+		if route.Services[i].Mirror {
+			continue
+		}
+
 		route.Services[i].Weight *= factor
 	}
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -237,6 +237,164 @@ func Test_createPatch(t *testing.T) {
 		wantErr       bool
 	}{
 		{
+			name: "Base",
+			args: args{
+				httpProxy: &contourv1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mocks.HTTPProxyName,
+					},
+					Spec: contourv1.HTTPProxySpec{
+						Routes: []contourv1.Route{
+							{
+								Services: []contourv1.Service{
+									{
+										Name:   mocks.StableServiceName,
+										Weight: 70,
+									},
+									{
+										Name:   mocks.CanaryServiceName,
+										Weight: 30,
+									},
+								},
+							},
+						},
+					},
+				},
+				rollout: &v1alpha1.Rollout{
+					Spec: v1alpha1.RolloutSpec{
+						Strategy: v1alpha1.RolloutStrategy{
+							Canary: &v1alpha1.CanaryStrategy{
+								StableService: mocks.StableServiceName,
+								CanaryService: mocks.CanaryServiceName,
+							},
+						},
+					},
+				},
+				desiredWeight: 50,
+			},
+			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":50},{"name":"argo-rollouts-canary","port":0,"weight":50}]}]}}`),
+			wantPatchType: k8stypes.MergePatchType,
+			wantErr:       false,
+		},
+		{
+			name: "Default weights",
+			args: args{
+				httpProxy: &contourv1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mocks.HTTPProxyName,
+					},
+					Spec: contourv1.HTTPProxySpec{
+						Routes: []contourv1.Route{
+							{
+								Services: []contourv1.Service{
+									{
+										Name:   mocks.StableServiceName,
+									},
+									{
+										Name:   mocks.CanaryServiceName,
+									},
+								},
+							},
+						},
+					},
+				},
+				rollout: &v1alpha1.Rollout{
+					Spec: v1alpha1.RolloutSpec{
+						Strategy: v1alpha1.RolloutStrategy{
+							Canary: &v1alpha1.CanaryStrategy{
+								StableService: mocks.StableServiceName,
+								CanaryService: mocks.CanaryServiceName,
+							},
+						},
+					},
+				},
+				desiredWeight: 50,
+			},
+			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":100},{"name":"argo-rollouts-canary","port":0,"weight":100}]}]}}`),
+			wantPatchType: k8stypes.MergePatchType,
+			wantErr:       false,
+		},
+		{
+			name: "Low sum",
+			args: args{
+				httpProxy: &contourv1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mocks.HTTPProxyName,
+					},
+					Spec: contourv1.HTTPProxySpec{
+						Routes: []contourv1.Route{
+							{
+								Services: []contourv1.Service{
+									{
+										Name:   mocks.StableServiceName,
+										Weight: 7,
+									},
+									{
+										Name:   mocks.CanaryServiceName,
+										Weight: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				rollout: &v1alpha1.Rollout{
+					Spec: v1alpha1.RolloutSpec{
+						Strategy: v1alpha1.RolloutStrategy{
+							Canary: &v1alpha1.CanaryStrategy{
+								StableService: mocks.StableServiceName,
+								CanaryService: mocks.CanaryServiceName,
+							},
+						},
+					},
+				},
+				desiredWeight: 50,
+			},
+			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":500},{"name":"argo-rollouts-canary","port":0,"weight":500}]}]}}`),
+			wantPatchType: k8stypes.MergePatchType,
+			wantErr:       false,
+		},
+		{
+			name: "High sum",
+			args: args{
+				httpProxy: &contourv1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: mocks.HTTPProxyName,
+					},
+					Spec: contourv1.HTTPProxySpec{
+						Routes: []contourv1.Route{
+							{
+								Services: []contourv1.Service{
+									{
+										Name:   mocks.StableServiceName,
+										Weight: 700,
+									},
+									{
+										Name:   mocks.CanaryServiceName,
+										Weight: 300,
+									},
+								},
+							},
+						},
+					},
+				},
+				rollout: &v1alpha1.Rollout{
+					Spec: v1alpha1.RolloutSpec{
+						Strategy: v1alpha1.RolloutStrategy{
+							Canary: &v1alpha1.CanaryStrategy{
+								StableService: mocks.StableServiceName,
+								CanaryService: mocks.CanaryServiceName,
+							},
+						},
+					},
+				},
+				desiredWeight: 50,
+			},
+			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":500},{"name":"argo-rollouts-canary","port":0,"weight":500}]}]}}`),
+			wantPatchType: k8stypes.MergePatchType,
+			wantErr:       false,
+		},
+		{
 			name: "Multiple services",
 			args: args{
 				httpProxy: &contourv1.HTTPProxy{
@@ -309,15 +467,15 @@ func Test_createPatch(t *testing.T) {
 								Services: []contourv1.Service{
 									{
 										Name:   mocks.StableServiceName,
-										Weight: 70,
+										Weight: 7,
 									},
 									{
 										Name:   mocks.CanaryServiceName,
-										Weight: 10,
+										Weight: 1,
 									},
 									{
 										Name:   "others-service",
-										Weight: 20,
+										Weight: 2,
 									},
 								},
 							},
@@ -336,7 +494,7 @@ func Test_createPatch(t *testing.T) {
 				},
 				desiredWeight: 50,
 			},
-			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":45},{"name":"argo-rollouts-canary","port":0,"weight":45},{"name":"others-service","port":0,"weight":10}]},{"services":[{"name":"argo-rollouts-stable","port":0,"weight":40},{"name":"argo-rollouts-canary","port":0,"weight":40},{"name":"others-service","port":0,"weight":20}]}]}}`),
+			want:          []byte(`{"spec":{"routes":[{"services":[{"name":"argo-rollouts-stable","port":0,"weight":45},{"name":"argo-rollouts-canary","port":0,"weight":45},{"name":"others-service","port":0,"weight":10}]},{"services":[{"name":"argo-rollouts-stable","port":0,"weight":400},{"name":"argo-rollouts-canary","port":0,"weight":400},{"name":"others-service","port":0,"weight":200}]}]}}`),
 			wantPatchType: k8stypes.MergePatchType,
 			wantErr:       false,
 		},

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -237,7 +237,7 @@ func Test_createPatch(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name: "test create http proxy patch",
+			name: "Multiple services",
 			args: args{
 				httpProxy: &contourv1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
@@ -281,7 +281,7 @@ func Test_createPatch(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "test create http proxy patch",
+			name: "Multiple routes",
 			args: args{
 				httpProxy: &contourv1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
@@ -341,7 +341,7 @@ func Test_createPatch(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "test create http proxy mirror patch",
+			name: "Mirror",
 			args: args{
 				httpProxy: &contourv1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Since https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-contour/pull/61 this plugin refuses to alter httpProxies whose weights sum to values different then 100. On the other hand, contour doesn't enforce any value for this sum (See [countour's documentation](https://projectcontour.io/docs/v1.6.1/httpproxy/#:~:text=HTTPProxy%20weighting%20follows%20some%20specific%20rules%3A)). This PR aims to handle all weight rules specified on contour's docs.

**Special notes for your reviewer**:

If the initial weight sum is very low, the plugin will lose a lot of precision when redirecting to canaries. (This is most likely the reason why the "equal to 100" check was made in the first place). For example: if both initial weights were set to 1, the only canary-stable ratios achievable would be 0%, 50%  and 100%.
To get around that, this PR boots weights by a factor of 100 whenever the weight sum is bellow 100.

When adding tests I noticed that some of them had duplicate names, so I also renamed them to better fit what they were testing.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
